### PR TITLE
PoC: シークバーの挙動を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ npm-debug.log
 spec/helpers/*.js
 coverage
 junitresults.xml
-lib
 tmp
 .idea
 doc/html

--- a/init.js
+++ b/init.js
@@ -1,18 +1,63 @@
 window.addEventListener("load", function() {
 	window.sandboxDeveloperProps.driver.gameCreatedTrigger.handle(function(game) {
 		window.sandboxDeveloperProps.game = game;
+		var gameDriver = window.sandboxDeveloperProps.driver;
+		var amflow = window.sandboxDeveloperProps.amflow;
+		var gdr = window.sandboxDeveloperProps.gdr;
+
+		var PlaybackController = require("./lib/PlaybackController");
+		var playbackController = new PlaybackController({
+			fps: game.fps,
+			game: game,
+			gdr: gdr,
+			driver: driver,
+			amflow: amflow,
+			handlers: {
+				requestUpdateView: set_time || function () {},
+				onReachReplayLast: function () {
+					driver.setNextAge(amflow._tickList[1] + 1);  // Ugh! 次ageの算出方法は暫定。
+					playbackController.switchToActive(function (e) { if (e) console.log(e); });
+				}
+			}
+		});
+
+		var seekBlue = document.getElementById("seek_blue");
+		var seekWhite = document.getElementById("seek_white");
+		var playstop = document.getElementById("playstop");
+		var speed = document.getElementById("speed");
+		if (seekBlue) {
+			function onClickSeekBar(e) {
+				var time = playbackController.getDuration() * e.offsetX / seekWhite.offsetWidth;
+				playbackController.setTime(time);
+				playbackController.switchToReplay(function (e) { if (e) console.log(e); });
+			}
+			seekBlue.addEventListener("click", onClickSeekBar);
+			seekWhite.addEventListener("click", onClickSeekBar);
+			playstop.addEventListener("click", function () {
+				playbackController.togglePaused();
+			});
+			speed.addEventListener("click", function () {
+				// Ugh! animation.js の speed_flag 更新を待つ setTimeout(). ちゃんと animation.js と統合すべき。
+				setTimeout(function () {
+					playbackController.setPlaybackRate(speed_flag);
+				}, 20);
+			});
+		}
+
 		var saveButton = document.getElementById("btn_save");
 		var loadButton = document.getElementById("btn_load");
 		if (window.RPGAtsumaru) {
 			var plugin = require("akashic-atsumaru-plugin");
 			plugin.init({
 				atsumaru: window.RPGAtsumaru,
-				game: window.sandboxDeveloperProps.game,
-				gameDriver: window.sandboxDeveloperProps.driver,
-				amflow: window.sandboxDeveloperProps.amflow,
-				gdr: window.sandboxDeveloperProps.gdr
+				game: game,
+				gameDriver: gameDriver,
+				amflow: amflow,
+				gdr: gdr
 			});
 		}
+
+		var debugOnMemoryDump = null;
 
 		// TODO: ちょっと不細工だけどいったんデバッグ用に
 		if (saveButton) {
@@ -21,21 +66,29 @@ window.addEventListener("load", function() {
 					game.external.atsumaru.storage.saveCurrentPlaylog("1");
 				} else {
 					// ただのデバッグ用
-					console.log("save playlog", window.sandboxDeveloperProps.amflow.dump());
+					console.log("save playlog", amflow.dump());
+					debugOnMemoryDump = JSON.stringify(amflow.dump());
 				}
 			});
 		}
-		var driver = window.sandboxDeveloperProps.driver;
 		if (loadButton) {
 			loadButton.addEventListener("click", function() {
-				if (window.RPGAtsumaru) {
-					game.external.atsumaru.storage.loadPlaylog("1");
+				if (window.RPGAtsumaru || debugOnMemoryDump) {
+					var p = window.RPGAtsumaru ? game.external.atsumaru.storage.load("1") : Promise.resolve(debugOnMemoryDump);
+					p.then(function (value) {
+						var playlog = JSON.parse(value);
+						amflow._tickList = playlog.tickList;  // Ugh! 非公開の値を直接書き換えている暫定処理
+						amflow._startPoints = playlog.startPoints;
+						playbackController.setTime(0);
+						playbackController.switchToReplay(function (e) { if (e) console.log(e); });
+					});
 				} else {
 					// ただのデバッグ用
 					console.log("load playlog");
 				}
 			});
 		}
+
 		return false;
 	});
 });

--- a/lib/PlaybackController.js
+++ b/lib/PlaybackController.js
@@ -1,0 +1,169 @@
+var TimeKeeper = require("./TimeKeeper");
+
+/*
+interface Params {
+	fps: number;
+	game: any;
+	gdr: any;
+	driver: any;
+	amflow: {
+		onTick: (fun: (tick: any) => void) => void;
+	};
+	handlers: {
+		onChangePaused?: (paused: boolean) => void;
+		requestUpdateView: (time: number, duration: number) => void;
+		onReachReplayLast: () => void;
+	};
+}
+*/
+
+function PlaybackController(params /* : Params */) {
+	this._onTick_bound = this._onTick.bind(this);
+	this._handleNotifyTime_bound = this._handleNotifyTime.bind(this);
+	this._isActive = true;
+	this._isPaused = false;
+	this._playbackRate = 1;
+	this._duration = 0;
+	this._time = 0;
+	this._fps = params.fps;
+	this._game = params.game;
+	this._gdr = params.gdr;
+	this._driver = params.driver;
+	this._amflow = params.amflow;
+	this._handlers = params.handlers;
+	this._timeKeeper = new TimeKeeper({
+		handleNotifyTime: this._handleNotifyTime_bound
+	});
+	this._amflow.onTick(this._onTick_bound);
+}
+
+var klass = PlaybackController;
+var proto = PlaybackController.prototype;
+
+klass.calculateDuration = function (tickList, fps) {
+	var lastAge = tickList[1];
+	var ticks = tickList[2] || [];
+	for (let i = ticks.length - 1; i >= 0; --i) {
+		var t = ticks[i];
+		var ts = klass.getTimestamp(t);
+		if (ts != null)
+			return ts + (lastAge - t[0]) * 1000 / fps;
+	}
+	return lastAge * 1000 / fps;
+};
+
+klass.getTimestamp = function (tick) {
+	var evs = tick[1];
+	if (!evs) return null;
+	for (var i = 0; i < evs.length; ++i) {
+		var ev = evs[i];
+		if (ev[0] === 0x2)
+			return ev[3];
+	}
+	return null;
+}
+
+proto.setTime = function (time) {
+	this._timeKeeper.setTime(time);
+};
+
+proto.setPlaybackRate = function (rate) {
+	this._playbackRate = rate;
+	this._updatePlaybackRate();
+};
+
+proto.getDuration = function () {
+	return this._duration;
+};
+
+proto.togglePaused = function () {
+	if (this._isActive) {
+		if (this._isPaused) {
+			this._driver.startGame();
+		} else {
+			this._driver.stopGame();
+		}
+	} else {
+		if (this._isPaused) {
+			this._timeKeeper.start();
+		} else {
+			this._timeKeeper.pause();
+		}
+	}
+	this._isPaused = !this._isPaused;
+	if (this._handlers.onChangePaused)
+		this._handlers.onChangePaused(this._isPaused);
+};
+
+proto.switchToReplay = function (callback) {
+	if (!this._isActive) return;
+	this._isActive = false;
+	this._updatePlaybackRate();
+	if (this._isPaused) {
+		this._driver.startGame();
+	} else {
+		this._timeKeeper.start();
+	}
+	this._driver.changeState({
+		driverConfiguration: {
+			executionMode: this._gdr.ExecutionMode.Passive,
+			eventBufferMode: { isSender: false, isReceiver: false }
+		},
+		loopConfiguration: {
+			loopMode: this._gdr.LoopMode.Replay,
+			delayIgnoreThreshold: Number.MAX_VALUE,
+			jumpTryThreshold: Number.MAX_VALUE,
+			targetTimeFunc: this._timeKeeper.getBoundTimeFunc()
+		}
+	}, callback);
+};
+
+proto.switchToActive = function (callback) {
+	if (this._isActive) return;
+	this._isActive = true;
+	this._updatePlaybackRate();
+	if (this._isPaused) {
+		this._driver.stopGame();
+	} else {
+		this._timeKeeper.pause();
+	}
+	this._driver.changeState({
+		driverConfiguration: {
+			executionMode: this._gdr.ExecutionMode.Active,
+			eventBufferMode: { isSender: false, isReceiver: true }
+		},
+		loopConfiguration: {
+			loopMode: this._gdr.LoopMode.Realtime,
+			delayIgnoreThreshold: 6,
+			jumpTryThreshold: 90000
+		}
+	}, callback);
+};
+
+proto._updatePlaybackRate = function () {
+	if (this._isActive) {
+		this._driver._gameLoop.setLoopConfiguration({ playbackRate: this._playbackRate });
+		this._timeKeeper.setRate(1);
+	} else {
+		this._driver._gameLoop.setLoopConfiguration({ playbackRate: 1 });
+		this._timeKeeper.setRate(this._playbackRate);
+	}
+};
+
+proto._onTick = function (tick) {
+	var ts = klass.getTimestamp(tick);
+	this._duration = ts ? ts : (this._duration + 1000 / this._fps);
+	var now = this._isActive ? this._duration : this._time;
+	this._handlers.requestUpdateView(now, this._duration);
+};
+
+proto._handleNotifyTime = function (time) {
+	this._time = time;
+	this._handlers.requestUpdateView(this._time, this._duration);
+	if (this._time >= this._duration && this._game.age >= this._amflow._tickList[1] && !this._isActive) {
+		var self = this;
+		setTimeout(function () { self._handlers.onReachReplayLast(); }, 0);
+	}
+};
+
+module.exports = PlaybackController;

--- a/lib/TimeKeeper.js
+++ b/lib/TimeKeeper.js
@@ -1,0 +1,58 @@
+function TimeKeeper(params) {
+	this._isRunning = false;
+	this._rate = 1;
+	this._offset = 0;
+	this._now = 0;
+	this._pausedAt = 0;
+	this._params = params;
+	this._getTime_bound = this.getTime.bind(this);
+}
+
+var proto = TimeKeeper.prototype;
+
+proto.getBoundTimeFunc = function () {
+	return this._getTime_bound;
+}
+
+proto.isRunning = function () {
+	return this._isRunning;
+};
+
+proto.getTime = function () {
+	var time = this._isRunning ? (Date.now() - this._origin) * this._rate + this._offset : this._pausedAt;
+	this._params.handleNotifyTime(time);
+	return time;
+};
+
+proto.setTime = function (time) {
+	this._offset = time;
+	this._origin = Date.now();
+	this._pausedAt = time;
+};
+
+proto.start = function () {
+	if (this._isRunning) return;
+	this._offset = this._pausedAt;
+	this._origin = Date.now();
+	this._isRunning = true;
+};
+
+proto.pause = function () {
+	if (!this._isRunning) return;
+
+	this._pausedAt = this.getTime();
+	this._isRunning = false;
+}
+
+proto.setRate = function (rate) {
+	if (this._rate === rate)
+		return;
+	this.setTime(this.getTime()); // _offsetをリセット
+	this._rate = rate;
+};
+
+proto.getRate = function () {
+	return this._rate;
+};
+
+module.exports = TimeKeeper;

--- a/rewrite.js
+++ b/rewrite.js
@@ -133,7 +133,7 @@ module.exports = function() {
 		'	<div class="seek_end"></div>',
 		'	<div class="seek_back">',
 		'		<div id="seek_blue"></div>',
-		'		<div class="seek_white"></div>',
+		'		<div id="seek_white"></div>',
 		'	</div>',
 		'</div>'
 	];

--- a/template/css/style.css
+++ b/template/css/style.css
@@ -130,7 +130,7 @@ body{
 	height:20px;
 	width:20px;
 	background-position:center;
-	background-image:url(../page/speed5_on.png);
+	background-image:url(../page/speed1_on.png);
 	filter:grayscale(100%) brightness(500%);
 	background-color:transparent;
 }
@@ -175,7 +175,7 @@ body{
 	background-color:#dcd052;
 }
 
-.seek_white{
+#seek_white{
 	position:absolute;
 	width:580px;
 	height:9px;

--- a/template/index.html
+++ b/template/index.html
@@ -47,7 +47,7 @@
 	<div class="seek_end"></div>
 	<div class="seek_back">
 		<div id="seek_blue"></div>
-		<div class="seek_white"></div>
+		<div id="seek_white"></div>
 	</div>
 </div>
 

--- a/template/js/atsumaru.js
+++ b/template/js/atsumaru.js
@@ -2,18 +2,63 @@
 window.addEventListener("load", function() {
 	window.sandboxDeveloperProps.driver.gameCreatedTrigger.handle(function(game) {
 		window.sandboxDeveloperProps.game = game;
+		var gameDriver = window.sandboxDeveloperProps.driver;
+		var amflow = window.sandboxDeveloperProps.amflow;
+		var gdr = window.sandboxDeveloperProps.gdr;
+
+		var PlaybackController = require("./lib/PlaybackController");
+		var playbackController = new PlaybackController({
+			fps: game.fps,
+			game: game,
+			gdr: gdr,
+			driver: driver,
+			amflow: amflow,
+			handlers: {
+				requestUpdateView: set_time || function () {},
+				onReachReplayLast: function () {
+					driver.setNextAge(amflow._tickList[1] + 1);  // Ugh! 次ageの算出方法は暫定。
+					playbackController.switchToActive(function (e) { if (e) console.log(e); });
+				}
+			}
+		});
+
+		var seekBlue = document.getElementById("seek_blue");
+		var seekWhite = document.getElementById("seek_white");
+		var playstop = document.getElementById("playstop");
+		var speed = document.getElementById("speed");
+		if (seekBlue) {
+			function onClickSeekBar(e) {
+				var time = playbackController.getDuration() * e.offsetX / seekWhite.offsetWidth;
+				playbackController.setTime(time);
+				playbackController.switchToReplay(function (e) { if (e) console.log(e); });
+			}
+			seekBlue.addEventListener("click", onClickSeekBar);
+			seekWhite.addEventListener("click", onClickSeekBar);
+			playstop.addEventListener("click", function () {
+				playbackController.togglePaused();
+			});
+			speed.addEventListener("click", function () {
+				// Ugh! animation.js の speed_flag 更新を待つ setTimeout(). ちゃんと animation.js と統合すべき。
+				setTimeout(function () {
+					playbackController.setPlaybackRate(speed_flag);
+				}, 20);
+			});
+		}
+
 		var saveButton = document.getElementById("btn_save");
 		var loadButton = document.getElementById("btn_load");
 		if (window.RPGAtsumaru) {
 			var plugin = require("akashic-atsumaru-plugin");
 			plugin.init({
 				atsumaru: window.RPGAtsumaru,
-				game: window.sandboxDeveloperProps.game,
-				gameDriver: window.sandboxDeveloperProps.driver,
-				amflow: window.sandboxDeveloperProps.amflow,
-				gdr: window.sandboxDeveloperProps.gdr
+				game: game,
+				gameDriver: gameDriver,
+				amflow: amflow,
+				gdr: gdr
 			});
 		}
+
+		var debugOnMemoryDump = null;
 
 		// TODO: ちょっと不細工だけどいったんデバッグ用に
 		if (saveButton) {
@@ -22,26 +67,265 @@ window.addEventListener("load", function() {
 					game.external.atsumaru.storage.saveCurrentPlaylog("1");
 				} else {
 					// ただのデバッグ用
-					console.log("save playlog", window.sandboxDeveloperProps.amflow.dump());
+					console.log("save playlog", amflow.dump());
+					debugOnMemoryDump = JSON.stringify(amflow.dump());
 				}
 			});
 		}
-		var driver = window.sandboxDeveloperProps.driver;
 		if (loadButton) {
 			loadButton.addEventListener("click", function() {
-				if (window.RPGAtsumaru) {
-					game.external.atsumaru.storage.loadPlaylog("1");
+				if (window.RPGAtsumaru || debugOnMemoryDump) {
+					var p = window.RPGAtsumaru ? game.external.atsumaru.storage.load("1") : Promise.resolve(debugOnMemoryDump);
+					p.then(function (value) {
+						var playlog = JSON.parse(value);
+						amflow._tickList = playlog.tickList;  // Ugh! 非公開の値を直接書き換えている暫定処理
+						amflow._startPoints = playlog.startPoints;
+						playbackController.setTime(0);
+						playbackController.switchToReplay(function (e) { if (e) console.log(e); });
+					});
 				} else {
 					// ただのデバッグ用
 					console.log("load playlog");
 				}
 			});
 		}
+
 		return false;
 	});
 });
 
-},{"akashic-atsumaru-plugin":2}],2:[function(require,module,exports){
+},{"./lib/PlaybackController":2,"akashic-atsumaru-plugin":4}],2:[function(require,module,exports){
+var TimeKeeper = require("./TimeKeeper");
+
+/*
+interface Params {
+	fps: number;
+	game: any;
+	gdr: any;
+	driver: any;
+	amflow: {
+		onTick: (fun: (tick: any) => void) => void;
+	};
+	handlers: {
+		onChangePaused?: (paused: boolean) => void;
+		requestUpdateView: (time: number, duration: number) => void;
+		onReachReplayLast: () => void;
+	};
+}
+*/
+
+function PlaybackController(params /* : Params */) {
+	this._onTick_bound = this._onTick.bind(this);
+	this._handleNotifyTime_bound = this._handleNotifyTime.bind(this);
+	this._isActive = true;
+	this._isPaused = false;
+	this._playbackRate = 1;
+	this._duration = 0;
+	this._time = 0;
+	this._fps = params.fps;
+	this._game = params.game;
+	this._gdr = params.gdr;
+	this._driver = params.driver;
+	this._amflow = params.amflow;
+	this._handlers = params.handlers;
+	this._timeKeeper = new TimeKeeper({
+		handleNotifyTime: this._handleNotifyTime_bound
+	});
+	this._amflow.onTick(this._onTick_bound);
+}
+
+var klass = PlaybackController;
+var proto = PlaybackController.prototype;
+
+klass.calculateDuration = function (tickList, fps) {
+	var lastAge = tickList[1];
+	var ticks = tickList[2] || [];
+	for (let i = ticks.length - 1; i >= 0; --i) {
+		var t = ticks[i];
+		var ts = klass.getTimestamp(t);
+		if (ts != null)
+			return ts + (lastAge - t[0]) * 1000 / fps;
+	}
+	return lastAge * 1000 / fps;
+};
+
+klass.getTimestamp = function (tick) {
+	var evs = tick[1];
+	if (!evs) return null;
+	for (var i = 0; i < evs.length; ++i) {
+		var ev = evs[i];
+		if (ev[0] === 0x2)
+			return ev[3];
+	}
+	return null;
+}
+
+proto.setTime = function (time) {
+	this._timeKeeper.setTime(time);
+};
+
+proto.setPlaybackRate = function (rate) {
+	this._playbackRate = rate;
+	this._updatePlaybackRate();
+};
+
+proto.getDuration = function () {
+	return this._duration;
+};
+
+proto.togglePaused = function () {
+	if (this._isActive) {
+		if (this._isPaused) {
+			this._driver.startGame();
+		} else {
+			this._driver.stopGame();
+		}
+	} else {
+		if (this._isPaused) {
+			this._timeKeeper.start();
+		} else {
+			this._timeKeeper.pause();
+		}
+	}
+	this._isPaused = !this._isPaused;
+	if (this._handlers.onChangePaused)
+		this._handlers.onChangePaused(this._isPaused);
+};
+
+proto.switchToReplay = function (callback) {
+	if (!this._isActive) return;
+	this._isActive = false;
+	this._updatePlaybackRate();
+	if (this._isPaused) {
+		this._driver.startGame();
+	} else {
+		this._timeKeeper.start();
+	}
+	this._driver.changeState({
+		driverConfiguration: {
+			executionMode: this._gdr.ExecutionMode.Passive,
+			eventBufferMode: { isSender: false, isReceiver: false }
+		},
+		loopConfiguration: {
+			loopMode: this._gdr.LoopMode.Replay,
+			delayIgnoreThreshold: Number.MAX_VALUE,
+			jumpTryThreshold: Number.MAX_VALUE,
+			targetTimeFunc: this._timeKeeper.getBoundTimeFunc()
+		}
+	}, callback);
+};
+
+proto.switchToActive = function (callback) {
+	if (this._isActive) return;
+	this._isActive = true;
+	this._updatePlaybackRate();
+	if (this._isPaused) {
+		this._driver.stopGame();
+	} else {
+		this._timeKeeper.pause();
+	}
+	this._driver.changeState({
+		driverConfiguration: {
+			executionMode: this._gdr.ExecutionMode.Active,
+			eventBufferMode: { isSender: false, isReceiver: true }
+		},
+		loopConfiguration: {
+			loopMode: this._gdr.LoopMode.Realtime,
+			delayIgnoreThreshold: 6,
+			jumpTryThreshold: 90000
+		}
+	}, callback);
+};
+
+proto._updatePlaybackRate = function () {
+	if (this._isActive) {
+		this._driver._gameLoop.setLoopConfiguration({ playbackRate: this._playbackRate });
+		this._timeKeeper.setRate(1);
+	} else {
+		this._driver._gameLoop.setLoopConfiguration({ playbackRate: 1 });
+		this._timeKeeper.setRate(this._playbackRate);
+	}
+};
+
+proto._onTick = function (tick) {
+	var ts = klass.getTimestamp(tick);
+	this._duration = ts ? ts : (this._duration + 1000 / this._fps);
+	var now = this._isActive ? this._duration : this._time;
+	this._handlers.requestUpdateView(now, this._duration);
+};
+
+proto._handleNotifyTime = function (time) {
+	this._time = time;
+	this._handlers.requestUpdateView(this._time, this._duration);
+	if (this._time >= this._duration && this._game.age >= this._amflow._tickList[1] && !this._isActive) {
+		var self = this;
+		setTimeout(function () { self._handlers.onReachReplayLast(); }, 0);
+	}
+};
+
+module.exports = PlaybackController;
+
+},{"./TimeKeeper":3}],3:[function(require,module,exports){
+function TimeKeeper(params) {
+	this._isRunning = false;
+	this._rate = 1;
+	this._offset = 0;
+	this._now = 0;
+	this._pausedAt = 0;
+	this._params = params;
+	this._getTime_bound = this.getTime.bind(this);
+}
+
+var proto = TimeKeeper.prototype;
+
+proto.getBoundTimeFunc = function () {
+	return this._getTime_bound;
+}
+
+proto.isRunning = function () {
+	return this._isRunning;
+};
+
+proto.getTime = function () {
+	var time = this._isRunning ? (Date.now() - this._origin) * this._rate + this._offset : this._pausedAt;
+	this._params.handleNotifyTime(time);
+	return time;
+};
+
+proto.setTime = function (time) {
+	this._offset = time;
+	this._origin = Date.now();
+	this._pausedAt = time;
+};
+
+proto.start = function () {
+	if (this._isRunning) return;
+	this._offset = this._pausedAt;
+	this._origin = Date.now();
+	this._isRunning = true;
+};
+
+proto.pause = function () {
+	if (!this._isRunning) return;
+
+	this._pausedAt = this.getTime();
+	this._isRunning = false;
+}
+
+proto.setRate = function (rate) {
+	if (this._rate === rate)
+		return;
+	this.setTime(this.getTime()); // _offsetをリセット
+	this._rate = rate;
+};
+
+proto.getRate = function () {
+	return this._rate;
+};
+
+module.exports = TimeKeeper;
+
+},{}],4:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||

--- a/template/page/animation.js
+++ b/template/page/animation.js
@@ -22,17 +22,40 @@ $(document).ready(function(){
 
 //シークバーの長さ※0～580px
 function seek_width(percent){
-    var seek_width;
-    seek_width = 5.8*percent;
+	var seek_width;
+	seek_width = 5.8*percent;
 	if(seek_width > 580){seek_width=580;}
 	return seek_width;
 }
 //スライダーの位置（シークバーの長さに合わせて)※197～777px
 
 //↓↓seek_width()にバーの位置の割合％を入力↓↓
+function seek_to(percent) {
+	$('#seek_blue').css('width', seek_width(percent));
+	$('#slyder').css('left', seek_width(percent)+197);
+}
+
+function set_time(time, duration) {
+	function padZero(n, len) {
+		var s = n.toString();
+		while (s.length < len)
+			s = "0" + s;
+		return s;
+	}
+	function format(t) {
+		var secs = Math.floor(t / 1000);
+		var s = secs % 60;
+		var mins = (secs - s) / 60;
+		var m = mins % 60;
+		var h = (mins - m) / 60;
+		return h + ':' + padZero(m, 2) + ':' + padZero(s, 2);
+	}
+	$('.timewindow').text(format(time) + " / " + format(duration));
+	seek_to(100 * time / duration);
+}
+
 $(window).load(function() {
-	$('#seek_blue').css('width', seek_width(100));
-	$('#slyder').css('left', seek_width(100)+197);
+	seek_to(100);
 });
 
 //シークバーメニュー
@@ -57,7 +80,7 @@ $(document).ready(function(){
 	});
 });
 
-var speed_flag = 5;
+var speed_flag = 1;
 $(document).ready(function(){
 	$('#speed').hover(function() {
 		$(this).css('filter','grayscale(0%) brightness(100%)');},


### PR DESCRIPTION
シークバーの挙動に試験的な実装を加えました。

## 主な機能的変更

- シークバーの再生・ポーズボタンの挙動を実装しました
- シークバーの余白クリック時のシーク動作を実装しました
- 再生速度倍率ボタンをクリックした時の挙動を実装しました
- プレイ完了時点で暗黙かつ自動的にプレイ状態に復帰するようにしました

## 主なソースコードの変更

- lib/TimeKeeper.js と lib/PlaybackController.js を追加
  - ビュー非依存の時間管理と内部モジュール制御を集約しています
- init.js で PlaybackController を利用してシークバーの挙動を実装
  - ビューへの依存はここに(暫定的に？)まとまっているようなのでここで処理します
- 一部ビューの操作はやむなく animation.js に加えました

## 補足

- Proof of Concept です。必ずしもマージすべき品質でないかもしれません。
  - akashic-atsumaru-plugin というパッケージと一部処理が重複しています。
- 特に animation.js に深入りせずにおいたため、必ずしも理想的な挙動でないであろう部分があります。
  - 高速リプレイでリプレイ完了すると高速なままプレイに復帰します。
    - animation.js が倍率の表示を独自に管理しているので、その構造を変えないと速度表示を戻せません。
  - シークバーのつまみをドラッグする操作は実装していません。
    - やることは本質的にはシークバークリック時と同じだと思います。
    - 感覚的には、過去方向へのドラッグをリアルタイムに再現するとジャンプしまくることになるので、過去方向に限ってはドロップ時に初めてジャンプするような制限が必要かもしれません。
- `window.RPGAtsumaru` がない場合には、オンメモリにセーブする処理を加えました。
- アツマール投稿時の動作は確認していません。